### PR TITLE
Feature/stephenquan/#58 mvvm nullable

### DIFF
--- a/samples/SQuan.Helpers.Maui.Sample/LocalizeDemo/LocalizePage.xaml
+++ b/samples/SQuan.Helpers.Maui.Sample/LocalizeDemo/LocalizePage.xaml
@@ -52,7 +52,9 @@
 
             <Entry Text="{Binding Expression, Mode=TwoWay}" />
 
-            <Label Text="{i18n:Localize LBL_RESULT, X0={local:Eval Expression={Binding Expression}, X0={Binding Count}, X1='10'}}" />
+            <local:NumericEntry Value="{Binding X1, Mode=TwoWay}" />
+
+            <Label Text="{i18n:Localize LBL_RESULT, X0={local:Eval Expression={Binding Expression}, X0={Binding Count}, X1={Binding X1}}}" />
 
             <Button
                 Command="{Binding ChangeUICultureCommand}"

--- a/samples/SQuan.Helpers.Maui.Sample/LocalizeDemo/LocalizePage.xaml.cs
+++ b/samples/SQuan.Helpers.Maui.Sample/LocalizeDemo/LocalizePage.xaml.cs
@@ -9,6 +9,8 @@ public partial class LocalizePage : ContentPage
 {
 	[ObservableProperty] public partial int Count { get; set; } = 0;
 
+	[ObservableProperty] public partial double? X1 { get; set; } = 10.0;
+
 	[ObservableProperty] public partial string Expression { get; set; } = "x0 * x1";
 
 	public List<CultureInfo> SupportedCultures { get; } =

--- a/samples/SQuan.Helpers.Maui.Sample/NumericEntry.cs
+++ b/samples/SQuan.Helpers.Maui.Sample/NumericEntry.cs
@@ -1,0 +1,36 @@
+using SQuan.Helpers.Maui.Mvvm;
+
+namespace SQuan.Helpers.Maui.Sample;
+
+public partial class NumericEntry : Entry
+{
+	[BindableProperty] public partial double? Value { get; set; } = null;
+
+	int Lock { get; set; } = 0;
+
+	public NumericEntry()
+	{
+		PropertyChanged += (sender, e) =>
+		{
+			switch (e.PropertyName)
+			{
+				case nameof(Text):
+					if (Lock == 0)
+					{
+						Lock++;
+						Value = (!string.IsNullOrEmpty(Text) && double.TryParse(Text, out double parsedValue)) ? parsedValue : null;
+						Lock--;
+					}
+					break;
+				case nameof(Value):
+					if (Lock == 0)
+					{
+						Lock++;
+						Text = (Value is null) ? string.Empty : Value.ToString();
+						Lock--;
+					}
+					break;
+			}
+		};
+	}
+}

--- a/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/BindablePropertyGenerator.cs
+++ b/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/BindablePropertyGenerator.cs
@@ -67,7 +67,12 @@ public class BindablePropertyGenerator : IIncrementalGenerator
 			var typeName = propertySymbol.Type.ToDisplayString();
 			var bareTypeName = typeName switch
 			{
+				"char?" => typeName,
+				"byte?" => typeName,
+				"short?" => typeName,
 				"int?" => typeName,
+				"long?" => typeName,
+				"float?" => typeName,
 				"double?" => typeName,
 				_ => typeName.Replace("?", "")
 			};

--- a/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/BindablePropertyGenerator.cs
+++ b/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/BindablePropertyGenerator.cs
@@ -65,7 +65,12 @@ public class BindablePropertyGenerator : IIncrementalGenerator
 			var namespaceName = classSymbol.ContainingNamespace.ToDisplayString();
 			var propertyName = propertySymbol.Name;
 			var typeName = propertySymbol.Type.ToDisplayString();
-			var bareTypeName = typeName.Replace("?", "");
+			var bareTypeName = typeName switch
+			{
+				"int?" => typeName,
+				"double?" => typeName,
+				_ => typeName.Replace("?", "")
+			};
 			PropertyDeclarationSyntax propertySyntax = (propertySymbol.DeclaringSyntaxReferences[0].GetSyntax() as PropertyDeclarationSyntax)!;
 
 			var propertyModifiers = propertySyntax.Modifiers


### PR DESCRIPTION
The typeof() operator supports nullability suffix `?` for basic types such as `byte`, `char`, `short`, `int`, `long`, `float`, and `double`.

When `?` is added to `object` or `string` it does not work, resulting in `error CS8639: The typeof operator cannot be used on a nullable reference type`, so we can only use the nullability suffix on the sanitized basic types.