### PR TITLE
Implement a configurable geometry cache

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,10 @@ indent_style = tab
 indent_size = 4
 
 # Code files
+[*.cs]
+file_header_template = {fileName}
+
+# Code files
 [*.sln]
 indent_size = 4
 

--- a/src/SQuan.Helpers.SQLiteSpatial/SQuan.Helpers.SQLiteSpatial.csproj
+++ b/src/SQuan.Helpers.SQLiteSpatial/SQuan.Helpers.SQLiteSpatial.csproj
@@ -59,6 +59,7 @@
     <PackageReference Include="ProjNET" Version="2.1.0" />
     <PackageReference Include="NetTopologySuite" Version="2.6.0" />
     <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
+    <PackageReference Include="System.Runtime.Caching" Version="9.0.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#90 

Use a frequency cache as a guard against a geometry cache to determine which WKT geometries should be remembered.