### PR TITLE
Provide more spatial index functions

### DIFF
--- a/samples/SQuan.Helpers.Sample/Pages/SpatialPage.xaml.cs
+++ b/samples/SQuan.Helpers.Sample/Pages/SpatialPage.xaml.cs
@@ -33,7 +33,7 @@ public partial class SpatialPage : ContentPage
 
 		// Experiment with creating spatial indexes.
 		db.Execute("CREATE INDEX IX_UsaStates_Name ON UsaStates (Name)");
-		db.Execute("CREATE INDEX IX_UsaStates_Geometry ON UsaStates (SP_S(Geometry), SP_Y(Geometry), SP_X(Geometry), SP_YMin(Geometry), SP_YMax(Geometry), SP_XMin(Geometry), SP_XMax(Geometry))");
+		db.Execute("CREATE INDEX IX_UsaStates_Geometry ON UsaStates (SP_S(Geometry), SP_Y(Geometry), SP_X(Geometry), SP_H2(Geometry), SP_W2(Geometry))");
 		db.Execute("CREATE INDEX IX_UsaCities_Geometry ON UsaCities (SP_Y(Geometry), SP_X(Geometry))");
 
 		// Do some test spatial queries
@@ -64,12 +64,10 @@ AND   SP_X(Geometry) BETWEEN -124.410607 AND -114.134458
 		results = db.Query<SpatialData>("""
 SELECT * FROM UsaStates
 WHERE SP_S(Geometry) IN (SELECT DISTINCT SP_S(Geometry) FROM UsaStates ORDER BY SP_S(Geometry) DESC)
-AND   SP_Y(Geometry) BETWEEN   32.534231 - SP_S(Geometry) AND   42.009659 + SP_S(Geometry)
-AND   SP_X(Geometry) BETWEEN -124.410607 - SP_S(Geometry) AND -114.134458 + SP_S(Geometry)
-AND   SP_XMin(Geometry) <= -124.410607
-AND   SP_XMax(Geometry) >= -114.134458
-AND   SP_YMin(Geometry) <= 42.009659
-AND   SP_YMax(Geometry) >= 32.534231
+AND   SP_Y(Geometry) BETWEEN   32.534231 - SP_S(Geometry)  AND   42.009659 + SP_S(Geometry)
+AND   SP_X(Geometry) BETWEEN -124.410607 - SP_S(Geometry)  AND -114.134458 + SP_S(Geometry)
+AND   SP_Y(Geometry) BETWEEN   32.534231 - SP_H2(Geometry) AND   42.009659 + SP_H2(Geometry)
+AND   SP_X(Geometry) BETWEEN -124.410607 - SP_W2(Geometry) AND -114.134458 + SP_W2(Geometry)
 """);
 		foreach (var result in results)
 		{

--- a/src/SQuan.Helpers.SQLiteSpatial/SQLiteSpatialExtension.cs
+++ b/src/SQuan.Helpers.SQLiteSpatial/SQLiteSpatialExtension.cs
@@ -74,630 +74,211 @@ public static class SQLiteSpatialExtensions
 	public static void EnableSpatialExtensions(this SQLiteConnection db)
 	{
 		var dbHandle = db.Handle;
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Area", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Area);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Boundary", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Boundary);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Buffer", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Buffer);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Centroid", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Centroid);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Contains", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Contains);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_ConvexHull", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_ConvexHull);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_CoveredBy", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_CoveredBy);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Covers", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Covers);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Crosses", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Crosses);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Difference", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Difference);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Disjoint", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Disjoint);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Distance", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Distance);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Equals", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Equals);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_EqualsExact", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_EqualsExact);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_EqualsNormalized", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_EqualsNormalized);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_EqualsTopologically", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_EqualsTopologically);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Envelope", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Envelope);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_GeometryType", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_GeometryType);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_InteriorPoint", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_InteriorPoint);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Intersection", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Intersection);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Intersects", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Intersects);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_IsEmpty", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_IsEmpty);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_IsRectangle", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_IsRectangle);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_IsSimple", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_IsSimple);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_IsValid", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_IsValid);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Length", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Length);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Point", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Point);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Reverse", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Reverse);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_SetSRID", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_SetSRID);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_SRID", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_SRID);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_SymmetricDifference", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_SymmetricDifference);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Touches", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Touches);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Union", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Union);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Within", 2, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Within);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_X", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_X);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "ST_Y", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, ST_Y);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "SP_S", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, SP_S);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "SP_X", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, SP_X);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "SP_XMin", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, SP_XMin);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "SP_XMax", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, SP_XMax);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "SP_Y", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, SP_Y);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "SP_YMin", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, SP_YMin);
-		SQLitePCL.raw.sqlite3_create_function(db.Handle, "SP_YMax", 1, SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC, null, SP_YMax);
+		CreateGeometryFunction<double?>(db.Handle, "ST_Area", (g) => g?.Area);
+		CreateGeometryFunction<string?>(db.Handle, "ST_Boundary", (g) => g?.Boundary?.AsText());
+		CreateGeometryDoubleFunction<string?>(db.Handle, "ST_Buffer", (g, d) => g?.Buffer(d)?.AsText());
+		CreateGeometryFunction<string?>(db.Handle, "ST_Centroid", (g) => g?.Centroid?.AsText());
+		CreateGeometryGeometryFunction<int>(db.Handle, "ST_Contains", (g, g2) => g?.Contains(g2) ?? false ? 1 : 0);
+		CreateGeometryFunction<string?>(db.Handle, "ST_ConvexHull", (g) => g?.ConvexHull()?.AsText());
+		CreateGeometryGeometryFunction<int>(db.Handle, "ST_CoveredBy", (g, g2) => g?.CoveredBy(g2) ?? false ? 1 : 0);
+		CreateGeometryGeometryFunction<int>(db.Handle, "ST_Covers", (g, g2) => g?.Covers(g2) ?? false ? 1 : 0);
+		CreateGeometryGeometryFunction<int>(db.Handle, "ST_Crosses", (g, g2) => g?.Crosses(g2) ?? false ? 1 : 0);
+		CreateGeometryGeometryFunction<string?>(db.Handle, "ST_Difference", (g, g2) => g?.Difference(g2)?.ToText());
+		CreateGeometryGeometryFunction<int>(db.Handle, "ST_Disjoint", (g, g2) => g?.Disjoint(g2) ?? false ? 1 : 0);
+		CreateGeometryGeometryFunction<double?>(db.Handle, "ST_Distance", (g, g2) => g?.Distance(g2));
+		CreateGeometryGeometryFunction<int>(db.Handle, "ST_Equals", (g, g2) => g?.Equals(g2) ?? false ? 1 : 0);
+		CreateGeometryGeometryFunction<int>(db.Handle, "ST_EqualsExact", (g, g2) => g?.EqualsExact(g2) ?? false ? 1 : 0);
+		CreateGeometryGeometryFunction<int>(db.Handle, "ST_EqualsNormalized", (g, g2) => g?.EqualsNormalized(g2) ?? false ? 1 : 0);
+		CreateGeometryGeometryFunction<int>(db.Handle, "ST_EqualsTopologically", (g, g2) => g?.EqualsTopologically(g2) ?? false ? 1 : 0);
+		CreateGeometryFunction<string?>(db.Handle, "ST_Envelope", (g) => g?.Envelope?.AsText());
+		CreateGeometryFunction<string?>(db.Handle, "ST_GeometryType", (g) => g?.GeometryType);
+		CreateGeometryFunction<string?>(db.Handle, "ST_IsRectangle", (g) => g?.InteriorPoint?.AsText());
+		CreateGeometryGeometryFunction<string?>(db.Handle, "ST_Intersection", (g, g2) => g?.Intersection(g2)?.AsText());
+		CreateGeometryGeometryFunction<int>(db.Handle, "ST_Intersects", (g, g2) => g?.Intersects(g2) ?? false ? 1 : 0);
+		CreateGeometryFunction<int>(db.Handle, "ST_IsEmpty", (g) => g?.IsEmpty ?? false ? 1 : 0);
+		CreateGeometryFunction<int>(db.Handle, "ST_IsRectangle", (g) => g?.IsRectangle ?? false ? 1 : 0);
+		CreateGeometryFunction<int>(db.Handle, "ST_IsSimple", (g) => g?.IsSimple ?? false ? 1 : 0);
+		CreateGeometryFunction<int>(db.Handle, "ST_IsValid", (g) => g?.IsValid ?? false ? 1 : 0);
+		CreateGeometryFunction<double?>(db.Handle, "ST_Length", (g) => g?.Length);
+		CreateDoubleDoubleFunction<string>(db.Handle, "ST_Point", (x, y) => new NetTopologySuite.Geometries.Point(x, y).AsText());
+		CreateGeometryFunction<string?>(db.Handle, "ST_SRID", (g) => g?.Reverse()?.ToText());
+		CreateGeometryIntegerFunction<string?>(db.Handle, "ST_SetSRID", (g, i) => { g?.SRID = i; return g?.ToText(); });
+		CreateGeometryFunction<int?>(db.Handle, "ST_SRID", (g) => g?.SRID);
+		CreateGeometryGeometryFunction<string?>(db.Handle, "ST_SymmetricDifference", (g, g2) => g?.SymmetricDifference(g2)?.ToText());
+		CreateGeometryGeometryFunction<int>(db.Handle, "ST_Touches", (g, g2) => g?.Touches(g2) ?? false ? 1 : 0);
+		CreateGeometryGeometryFunction<string?>(db.Handle, "ST_Union", (g, g2) => g?.Union(g2)?.ToText());
+		CreateGeometryGeometryFunction<int>(db.Handle, "ST_Within", (g, g2) => g?.Within(g2) ?? false ? 1 : 0);
+		CreateGeometryGeometryFunction<double?>(db.Handle, "ST_X", (g, g2) => g?.Centroid.X);
+		CreateGeometryGeometryFunction<double?>(db.Handle, "ST_Y", (g, g2) => g?.Centroid.Y);
+		CreateSpatialIndexFunction<double?>(db.Handle, "SP_H", (SpatialIndex? s) => s?.Height);
+		CreateSpatialIndexFunction<double?>(db.Handle, "SP_H2", (SpatialIndex? s) => s?.Height / 2.0);
+		CreateSpatialIndexFunction<double?>(db.Handle, "SP_S", (SpatialIndex? s) => s?.Size);
+		CreateSpatialIndexFunction<double?>(db.Handle, "SP_W", (SpatialIndex? s) => s?.Width);
+		CreateSpatialIndexFunction<double?>(db.Handle, "SP_W2", (SpatialIndex? s) => s?.Width / 2.0);
+		CreateSpatialIndexFunction<double?>(db.Handle, "SP_X", (SpatialIndex? s) => s?.CenterX);
+		CreateSpatialIndexFunction<double?>(db.Handle, "SP_XMin", (SpatialIndex? s) => s?.X1);
+		CreateSpatialIndexFunction<double?>(db.Handle, "SP_XMax", (SpatialIndex? s) => s?.X2);
+		CreateSpatialIndexFunction<double?>(db.Handle, "SP_Y", (SpatialIndex? s) => s?.CenterY);
+		CreateSpatialIndexFunction<double?>(db.Handle, "SP_YMin", (SpatialIndex? s) => s?.Y1);
+		CreateSpatialIndexFunction<double?>(db.Handle, "SP_YMax", (SpatialIndex? s) => s?.Y2);
 	}
 
 	/// <summary>
-	/// Implements the ST_Area function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Area(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<double?>(ctx, user_data, args, (g) => g?.Area);
-
-	/// <summary>
-	/// Implements the ST_Boundary function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Boundary(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<string?>(ctx, user_data, args,
-			(g) => g?.Boundary is NetTopologySuite.Geometries.Geometry result ? result.AsText() : null);
-
-	/// <summary>
-	/// Implements the ST_Buffer function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Buffer(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryDoubleFunction<string?>(ctx, user_data, args,
-			(g, d) => g?.Buffer(d) is NetTopologySuite.Geometries.Geometry b ? b.AsText() : null);
-
-	/// <summary>
-	/// Implements the ST_Centroid function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Centroid(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<string?>(ctx, user_data, args,
-			(g) => g?.Centroid is NetTopologySuite.Geometries.Point p ? p.AsText() : null);
-
-	/// <summary>
-	/// Implements the ST_Contains function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Contains(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<int>(ctx, user_data, args, (g, g2) => g?.Contains(g2) ?? false ? 1 : 0);
-
-	/// <summary>
-	/// Implements the ST_ConvexHull function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_ConvexHull(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<string?>(ctx, user_data, args,
-			(g) => g?.ConvexHull() is NetTopologySuite.Geometries.Geometry result ? result.AsText() : null);
-
-	/// <summary>
-	/// Implements the ST_CoveredBy function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_CoveredBy(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<int>(ctx, user_data, args, (g, g2) => g?.CoveredBy(g2) ?? false ? 1 : 0);
-
-	/// <summary>
-	/// Implements the ST_Covers function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Covers(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<int>(ctx, user_data, args, (g, g2) => g?.Covers(g2) ?? false ? 1 : 0);
-
-	/// <summary>
-	/// Implements the ST_Crosses function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Crosses(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<int>(ctx, user_data, args, (g, g2) => g?.Crosses(g2) ?? false ? 1 : 0);
-
-	/// <summary>
-	/// Implements the ST_Difference function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Difference(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<string?>(ctx, user_data, args,
-			(g, g2) => g?.Difference(g2) is NetTopologySuite.Geometries.Geometry result ? result.AsText() : null);
-
-	/// <summary>
-	/// Implements the ST_Disjoint function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Disjoint(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<int>(ctx, user_data, args, (g, g2) => g?.Disjoint(g2) ?? false ? 1 : 0);
-
-	/// <summary>
-	/// Implements the ST_Distance function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Distance(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<double?>(ctx, user_data, args, (g, g2) => g?.Distance(g2));
-
-	/// <summary>
-	/// Implements the ST_Envelope function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Envelope(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<string?>(ctx, user_data, args,
-			(g) => g?.Envelope is NetTopologySuite.Geometries.Geometry result ? result.AsText() : null);
-
-	/// <summary>
-	/// Implements the ST_Equals function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Equals(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<int>(ctx, user_data, args, (g, g2) => g?.Equals(g2) ?? false ? 1 : 0);
-
-	/// <summary>
-	/// Implements the ST_EqualsExact function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_EqualsExact(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<int>(ctx, user_data, args, (g, g2) => g?.EqualsExact(g2) ?? false ? 1 : 0);
-
-	/// <summary>
-	/// Implements the ST_EqualsNormalized function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_EqualsNormalized(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<int>(ctx, user_data, args, (g, g2) => g?.EqualsNormalized(g2) ?? false ? 1 : 0);
-
-	/// <summary>
-	/// Implements the ST_EqualsTopologically function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_EqualsTopologically(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<int>(ctx, user_data, args, (g, g2) => g?.EqualsTopologically(g2) ?? false ? 1 : 0);
-
-	/// <summary>
-	/// Implements the ST_GeometryType function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_GeometryType(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<string?>(ctx, user_data, args, (g) => g?.GeometryType);
-
-	/// <summary>
-	/// Implements the ST_InteriorPoint function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_InteriorPoint(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<string?>(ctx, user_data, args,
-			(g) => g?.InteriorPoint is NetTopologySuite.Geometries.Point result ? result.AsText() : null);
-
-	/// <summary>
-	/// Implements the ST_Intersection function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Intersection(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<string?>(ctx, user_data, args,
-			(g, g2) => g?.Intersection(g2) is NetTopologySuite.Geometries.Geometry result ? result.AsText() : null);
-
-	/// <summary>
-	/// Implements the ST_Intersects function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Intersects(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<int>(ctx, user_data, args, (g, g2) => g?.Intersects(g2) ?? false ? 1 : 0);
-
-	/// <summary>
-	/// Implements the ST_IsEmpty function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_IsEmpty(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<int>(ctx, user_data, args, (g) => g?.IsEmpty ?? true ? 1 : 0);
-
-	/// <summary>
-	/// Implements the ST_IsRectangle function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_IsRectangle(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<int>(ctx, user_data, args, (g) => g?.IsRectangle ?? false ? 1 : 0);
-
-	/// <summary>
-	/// Implements the ST_IsSimple function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_IsSimple(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<int>(ctx, user_data, args, (g) => g?.IsSimple ?? false ? 1 : 0);
-
-	/// <summary>
-	/// Implements the ST_IsValid function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_IsValid(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<int>(ctx, user_data, args, (g) => g?.IsValid ?? false ? 1 : 0);
-
-	/// <summary>
-	/// Implements the ST_Length function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Length(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<double?>(ctx, user_data, args, (g) => g?.Length);
-
-	/// <summary>
-	/// Implements the ST_Point function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Point(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-	{
-		try
-		{
-			double x = raw.sqlite3_value_double(args[0]);
-			double y = raw.sqlite3_value_double(args[1]);
-			var geometry = new NetTopologySuite.Geometries.Point(x, y);
-			SetResult(ctx, geometry.AsText());
-		}
-		catch (Exception ex)
-		{
-			SetResultError(ctx, ex);
-		}
-	}
-
-	/// <summary>
-	/// Implements the ST_Reverse function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Reverse(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<string?>(ctx, user_data, args,
-			(g) => g?.Reverse() is NetTopologySuite.Geometries.Geometry result ? result.AsText() : null);
-
-	/// <summary>
-	/// Implements the ST_SymmetricDifference function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_SymmetricDifference(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<string?>(ctx, user_data, args,
-			(g, g2) => g?.SymmetricDifference(g2) is NetTopologySuite.Geometries.Geometry result ? result.AsText() : null);
-
-	/// <summary>
-	/// Implements the ST_SetSRID function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_SetSRID(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryIntegerFunction<string?>(ctx, user_data, args,
-			(g, i) => (g is not null && (g.SRID = i) == i) ? g.AsText() : null);
-
-	/// <summary>
-	/// Implements the ST_SRID function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_SRID(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<int?>(ctx, user_data, args, (g) => g?.SRID);
-
-	/// <summary>
-	/// Implements the ST_Touches function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Touches(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<int>(ctx, user_data, args, (g, g2) => g?.Touches(g2) ?? false ? 1 : 0);
-
-	/// <summary>
-	/// Implements the ST_Union function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Union(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<string?>(ctx, user_data, args,
-			(g, g2) => g?.Union(g2) is NetTopologySuite.Geometries.Geometry result ? result.AsText() : null);
-
-	/// <summary>
-	/// Implements the ST_Within function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Within(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryGeometryFunction<int>(ctx, user_data, args, (g, g2) => g?.Within(g2) ?? false ? 1 : 0);
-
-	/// <summary>
-	/// Implements the ST_X function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_X(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<double?>(ctx, user_data, args, (g) => g is null ? null : g.Envelope.Centroid.X);
-
-	/// <summary>
-	/// Implements the ST_Y function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void ST_Y(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<double?>(ctx, user_data, args, (g) => g is null ? null : g.Envelope.Centroid.Y);
-
-	/// <summary>
-	/// Implements the SP_S spatial index function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void SP_S(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<double?>(ctx, user_data, args,
-			(g) =>
-			{
-				if (g is NetTopologySuite.Geometries.Point p)
-				{
-					return 0.0;
-				}
-				if (g?.Envelope is NetTopologySuite.Geometries.Geometry e && e.Coordinates.Length == 5)
-				{
-					double d = Math.Max(e.Coordinates[2].X - e.Coordinates[0].X, e.Coordinates[2].Y - e.Coordinates[0].Y) / 2.0;
-					return (d <= 0.0) ? 0.0 : Math.Pow(2.0, Math.Ceiling(Math.Log(d, 2.0)));
-				}
-				return null;
-			});
-
-	/// <summary>
-	/// Implements the SP_X spatial index function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void SP_X(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<double?>(ctx, user_data, args,
-			(g) =>
-			{
-				if (g is NetTopologySuite.Geometries.Point p)
-				{
-					return p.X;
-				}
-				if (g?.Envelope is NetTopologySuite.Geometries.Geometry e && e.Coordinates.Length == 5)
-				{
-					return (e.Coordinates[2].X + e.Coordinates[0].X) / 2.0;
-				}
-				return null;
-			});
-
-	/// <summary>
-	/// Implements the SP_XMin spatial index function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void SP_XMin(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<double?>(ctx, user_data, args,
-			(g) =>
-			{
-				if (g is NetTopologySuite.Geometries.Point p)
-				{
-					return p.X;
-				}
-				if (g?.Envelope is NetTopologySuite.Geometries.Geometry e && e.Coordinates.Length == 5)
-				{
-					return e.Coordinates[0].X;
-				}
-				return null;
-			});
-
-	/// <summary>
-	///  Implements the SP_XMax spatial index function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void SP_XMax(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<double?>(ctx, user_data, args,
-			(g) =>
-			{
-				if (g is NetTopologySuite.Geometries.Point p)
-				{
-					return p.X;
-				}
-				if (g?.Envelope is NetTopologySuite.Geometries.Geometry e && e.Coordinates.Length == 5)
-				{
-					return e.Coordinates[2].X;
-				}
-				return null;
-			});
-
-	/// <summary>
-	/// Implements the SP_Y spatial index function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void SP_Y(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<double?>(ctx, user_data, args,
-			(g) =>
-			{
-				if (g is NetTopologySuite.Geometries.Point p)
-				{
-					return p.Y;
-				}
-				if (g?.Envelope is NetTopologySuite.Geometries.Geometry e && e.Coordinates.Length == 5)
-				{
-					return (e.Coordinates[2].Y + e.Coordinates[0].Y) / 2.0;
-				}
-				return null;
-			});
-
-	/// <summary>
-	///  Implements the SP_YMin spatial index function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void SP_YMin(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<double?>(ctx, user_data, args,
-			(g) =>
-			{
-				if (g is NetTopologySuite.Geometries.Point p)
-				{
-					return p.X;
-				}
-				if (g?.Envelope is NetTopologySuite.Geometries.Geometry e && e.Coordinates.Length == 5)
-				{
-					return e.Coordinates[0].Y;
-				}
-				return null;
-			});
-
-	/// <summary>
-	///  Implements the SP_YMax spatial index function for SQLite.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	static void SP_YMax(sqlite3_context ctx, object user_data, sqlite3_value[] args)
-		=> ST_GeometryFunction<double?>(ctx, user_data, args,
-			(g) =>
-			{
-				if (g is NetTopologySuite.Geometries.Point p)
-				{
-					return p.X;
-				}
-				if (g?.Envelope is NetTopologySuite.Geometries.Geometry e && e.Coordinates.Length == 5)
-				{
-					return e.Coordinates[2].Y;
-				}
-				return null;
-			});
-
-	/// <summary>
-	/// Internal helper to handle geometry-based SQLite functions.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	/// <param name="func"></param>
-	static void ST_GeometryFunction<T>(sqlite3_context ctx, object user_data, sqlite3_value[] args, Func<Geometry?, T> func)
-	{
-		try
-		{
-			var geometry = ToGeometry(raw.sqlite3_value_text(args[0]).utf8_to_string());
-			SetResult(ctx, func(geometry));
-		}
-		catch (Exception ex)
-		{
-			SetResultError(ctx, ex);
-		}
-	}
-
-	/// <summary>
-	/// Internal helper to handle geometry and double-based SQLite functions.
-	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
-	/// <param name="func"></param>
-	static void ST_GeometryDoubleFunction<T>(sqlite3_context ctx, object user_data, sqlite3_value[] args, Func<Geometry?, double, T> func)
-	{
-		try
-		{
-			var geometry = ToGeometry(raw.sqlite3_value_text(args[0]).utf8_to_string());
-			double d = raw.sqlite3_value_double(args[1]);
-			SetResult(ctx, func(geometry, d));
-		}
-		catch (Exception ex)
-		{
-			SetResultError(ctx, ex);
-		}
-	}
-
-	/// <summary>
-	/// Internal helper to handle two-geometry-based SQLite functions.
+	/// Internal method to create double double functions in SQLite.
 	/// </summary>
 	/// <typeparam name="T"></typeparam>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
+	/// <param name="handle"></param>
+	/// <param name="name"></param>
 	/// <param name="func"></param>
-	static void ST_GeometryGeometryFunction<T>(sqlite3_context ctx, object user_data, sqlite3_value[] args, Func<Geometry?, Geometry?, T> func)
+	/// <param name="flags"></param>
+	static void CreateDoubleDoubleFunction<T>(sqlite3 handle, string name, Func<double, double, T> func, int flags = SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC)
 	{
-		try
+		SQLitePCL.raw.sqlite3_create_function(handle, name, 2, flags, null, (sqlite3_context ctx, object user_data, sqlite3_value[] args) =>
 		{
-			var geometry = ToGeometry(raw.sqlite3_value_text(args[0]).utf8_to_string());
-			var geometry2 = ToGeometry(raw.sqlite3_value_text(args[1]).utf8_to_string());
-			SetResult(ctx, func(geometry, geometry2));
-		}
-		catch (Exception ex)
-		{
-			SetResultError(ctx, ex);
-		}
+			try
+			{
+				double d = raw.sqlite3_value_double(args[0]);
+				double d2 = raw.sqlite3_value_double(args[1]);
+				SetResult(ctx, func(d, d2));
+			}
+			catch (Exception ex)
+			{
+				SetResultError(ctx, ex);
+			}
+		});
 	}
 
 	/// <summary>
-	/// Internal helper to handle geometry and double-based SQLite functions.
+	/// Internal method to create geometry functions in SQLite.
 	/// </summary>
-	/// <param name="ctx"></param>
-	/// <param name="user_data"></param>
-	/// <param name="args"></param>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="handle"></param>
+	/// <param name="name"></param>
 	/// <param name="func"></param>
-	static void ST_GeometryIntegerFunction<T>(sqlite3_context ctx, object user_data, sqlite3_value[] args, Func<Geometry?, int, T> func)
+	/// <param name="flags"></param>
+	static void CreateGeometryFunction<T>(sqlite3 handle, string name, Func<NetTopologySuite.Geometries.Geometry?, T> func, int flags = SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC)
 	{
-		try
+		SQLitePCL.raw.sqlite3_create_function(handle, name, 1, flags, null, (sqlite3_context ctx, object user_data, sqlite3_value[] args) =>
 		{
-			var geometry = ToGeometry(raw.sqlite3_value_text(args[0]).utf8_to_string());
-			int i = raw.sqlite3_value_int(args[1]);
-			WKTReader reader = new();
-			SetResult(ctx, func(geometry, i));
-		}
-		catch (Exception ex)
+			try
+			{
+				var geometry = ToGeometry(raw.sqlite3_value_text(args[0]).utf8_to_string());
+				SetResult(ctx, func(geometry));
+			}
+			catch (Exception ex)
+			{
+				SetResultError(ctx, ex);
+			}
+		});
+	}
+
+	/// <summary>
+	/// Internal method to create geometry double functions in SQLite.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="handle"></param>
+	/// <param name="name"></param>
+	/// <param name="func"></param>
+	/// <param name="flags"></param>
+	static void CreateGeometryDoubleFunction<T>(sqlite3 handle, string name, Func<NetTopologySuite.Geometries.Geometry?, double, T> func, int flags = SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC)
+	{
+		SQLitePCL.raw.sqlite3_create_function(handle, name, 2, flags, null, (sqlite3_context ctx, object user_data, sqlite3_value[] args) =>
 		{
-			SetResultError(ctx, ex);
-		}
+			try
+			{
+				var geometry = ToGeometry(raw.sqlite3_value_text(args[0]).utf8_to_string());
+				double d = raw.sqlite3_value_double(args[1]);
+				SetResult(ctx, func(geometry, d));
+			}
+			catch (Exception ex)
+			{
+				SetResultError(ctx, ex);
+			}
+		});
+	}
+
+	/// <summary>
+	/// Internal method to create geometry geometry functions in SQLite.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="handle"></param>
+	/// <param name="name"></param>
+	/// <param name="func"></param>
+	/// <param name="flags"></param>
+	static void CreateGeometryGeometryFunction<T>(sqlite3 handle, string name, Func<NetTopologySuite.Geometries.Geometry?, NetTopologySuite.Geometries.Geometry?, T> func, int flags = SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC)
+	{
+		SQLitePCL.raw.sqlite3_create_function(handle, name, 2, flags, null, (sqlite3_context ctx, object user_data, sqlite3_value[] args) =>
+		{
+			try
+			{
+				var geometry = ToGeometry(raw.sqlite3_value_text(args[0]).utf8_to_string());
+				var geometry2 = ToGeometry(raw.sqlite3_value_text(args[1]).utf8_to_string());
+				SetResult(ctx, func(geometry, geometry2));
+			}
+			catch (Exception ex)
+			{
+				SetResultError(ctx, ex);
+			}
+		});
+	}
+
+	/// <summary>
+	/// Internal method to create geometry integer functions in SQLite.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="handle"></param>
+	/// <param name="name"></param>
+	/// <param name="func"></param>
+	/// <param name="flags"></param>
+	static void CreateGeometryIntegerFunction<T>(sqlite3 handle, string name, Func<NetTopologySuite.Geometries.Geometry?, int, T> func, int flags = SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC)
+	{
+		SQLitePCL.raw.sqlite3_create_function(handle, name, 2, flags, null, (sqlite3_context ctx, object user_data, sqlite3_value[] args) =>
+		{
+			try
+			{
+				var geometry = ToGeometry(raw.sqlite3_value_text(args[0]).utf8_to_string());
+				int i = raw.sqlite3_value_int(args[1]);
+				SetResult(ctx, func(geometry, i));
+			}
+			catch (Exception ex)
+			{
+				SetResultError(ctx, ex);
+			}
+		});
+	}
+
+	/// <summary>
+	/// Internal method to create spatial index functions in SQLite.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="handle"></param>
+	/// <param name="name"></param>
+	/// <param name="func"></param>
+	/// <param name="flags"></param>
+	static void CreateSpatialIndexFunction<T>(sqlite3 handle, string name, Func<SpatialIndex?, T> func, int flags = SQLitePCL.raw.SQLITE_UTF8 | SQLitePCL.raw.SQLITE_DETERMINISTIC)
+	{
+		SQLitePCL.raw.sqlite3_create_function(handle, name, 1, flags, null, (sqlite3_context ctx, object user_data, sqlite3_value[] args) =>
+		{
+			try
+			{
+				var geometry = ToGeometry(raw.sqlite3_value_text(args[0]).utf8_to_string());
+				if (geometry is NetTopologySuite.Geometries.Point p)
+				{
+					SetResult(ctx, func(new SpatialIndex(p.X, p.Y, p.X, p.Y)));
+					return;
+				}
+				if (geometry?.Envelope is NetTopologySuite.Geometries.Geometry e && e.Coordinates.Length == 5)
+				{
+					SetResult(ctx, func(new SpatialIndex(e.Coordinates[0].X, e.Coordinates[0].Y, e.Coordinates[2].X, e.Coordinates[2].Y)));
+					return;
+				}
+				SetResult(ctx, func(null));
+			}
+			catch (Exception ex)
+			{
+				SetResultError(ctx, ex);
+			}
+		});
 	}
 
 
@@ -737,5 +318,82 @@ public static class SQLiteSpatialExtensions
 	{
 		raw.sqlite3_result_error(ctx, utf8z.FromString(ex.Message));
 		raw.sqlite3_result_error_code(ctx, raw.SQLITE_ERROR);
+	}
+
+	/// <summary>
+	/// Internal class representing a spatial index with bounding box properties.
+	/// </summary>
+	class SpatialIndex
+	{
+		/// <summary>
+		/// Gets or sets the minimum X coordinate.
+		/// </summary>
+		public double X1 { get; set; }
+
+		/// <summary>
+		/// Gets or sets the minimum Y coordinate.
+		/// </summary>
+		public double Y1 { get; set; }
+
+		/// <summary>
+		/// Gets or sets the maximum X coordinate.
+		/// </summary>
+		public double X2 { get; set; }
+
+		/// <summary>
+		/// Gets or sets the maximum Y coordinate.
+		/// </summary>
+		public double Y2 { get; set; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="SpatialIndex"/> class.
+		/// </summary>
+		/// <param name="x1"></param>
+		/// <param name="y1"></param>
+		/// <param name="x2"></param>
+		/// <param name="y2"></param>
+		public SpatialIndex(double x1, double y1, double x2, double y2)
+		{
+			X1 = x1;
+			Y1 = y1;
+			X2 = x2;
+			Y2 = y2;
+		}
+
+		/// <summary>
+		/// Gets the width of the spatial index.
+		/// </summary>
+		public double Width => X2 - X1;
+
+		/// <summary>
+		/// Gets the height of the spatial index.
+		/// </summary>
+		public double Height => Y2 - Y1;
+
+		/// <summary>
+		/// Gets the center X coordinate of the spatial index.
+		/// </summary>
+		public double CenterX => (X1 + X2) / 2;
+
+		/// <summary>
+		/// Gets the center Y coordinate of the spatial index.
+		/// </summary>
+		public double CenterY => (Y1 + Y2) / 2;
+
+		/// <summary>
+		/// Gets the size of the spatial index, rounded up to the nearest power of two.
+		/// </summary>
+		public double Size
+		{
+			get
+			{
+				double size = Math.Max(Width, Height);
+				if (size <= 0)
+				{
+					return 0;
+				}
+				return Math.Pow(2.0, Math.Ceiling(Math.Log(size, 2.0)));
+			}
+		}
 	}
 }


### PR DESCRIPTION
#93 

The spatial index functions are experimental.
It's safer to provide a bunch of choices so that the caller can determine how to use them.
Also a refactor / cleanup was identified by wrapping the sqlite3_create_function calls.