### PR TITLE
Refactor/replace with a basic full-scan polygon spatial index example.

### DIFF
--- a/samples/SQuan.Helpers.Sample/Models/QueryPlan.cs
+++ b/samples/SQuan.Helpers.Sample/Models/QueryPlan.cs
@@ -1,0 +1,23 @@
+﻿// QueryPlan.cs
+
+using SQLite;
+
+namespace SQuan.Helpers.Sample;
+
+/// <summary>
+/// Query plan model for SQLite EXPLAIN QUERY PLAN results.
+/// </summary>
+public class QueryPlan
+{
+	[Column("id")]
+	public int Id { get; set; }
+
+	[Column("parent")]
+	public int Parent { get; set; }
+
+	[Column("notused")]
+	public int NotUsed { get; set; }
+
+	[Column("detail")]
+	public string Detail { get; set; } = string.Empty;
+}

--- a/src/SQuan.Helpers.SQLiteSpatial/SQLiteSpatialExtension.cs
+++ b/src/SQuan.Helpers.SQLiteSpatial/SQLiteSpatialExtension.cs
@@ -112,7 +112,7 @@ public static class SQLiteSpatialExtensions
 		CreateGeometryGeometryFunction<double?>(db.Handle, "ST_Y", (g, g2) => g?.Centroid.Y);
 		CreateSpatialIndexFunction<double?>(db.Handle, "SP_H", (SpatialIndex? s) => s?.Height);
 		CreateSpatialIndexFunction<double?>(db.Handle, "SP_H2", (SpatialIndex? s) => s?.Height / 2.0);
-		CreateSpatialIndexFunction<double?>(db.Handle, "SP_S", (SpatialIndex? s) => s?.Size);
+		CreateSpatialIndexFunction<int?>(db.Handle, "SP_S", (SpatialIndex? s) => s?.Size);
 		CreateSpatialIndexFunction<double?>(db.Handle, "SP_W", (SpatialIndex? s) => s?.Width);
 		CreateSpatialIndexFunction<double?>(db.Handle, "SP_W2", (SpatialIndex? s) => s?.Width / 2.0);
 		CreateSpatialIndexFunction<double?>(db.Handle, "SP_X", (SpatialIndex? s) => s?.CenterX);
@@ -383,16 +383,16 @@ public static class SQLiteSpatialExtensions
 		/// <summary>
 		/// Gets the size of the spatial index, rounded up to the nearest power of two.
 		/// </summary>
-		public double Size
+		public int? Size
 		{
 			get
 			{
 				double size = Math.Max(Width, Height);
 				if (size <= 0)
 				{
-					return 0;
+					return null;
 				}
-				return Math.Pow(2.0, Math.Ceiling(Math.Log(size, 2.0)));
+				return (int)Math.Ceiling(Math.Log(size, 2.0));
 			}
 		}
 	}


### PR DESCRIPTION
#93 

After checking some query plans, it was found that the SYX polygon search index wasn't used effectively.
More experiments need to be carried out.
In the meantime, the example has been updated to reflect how to do an index scan (similar to a table scan) to use the precalculated values from the index.