### PR TITLE
Make spatial index functions consistent. 

### DIFF
--- a/samples/SQuan.Helpers.Sample/Resources/Raw/schema.sql
+++ b/samples/SQuan.Helpers.Sample/Resources/Raw/schema.sql
@@ -43,19 +43,19 @@ BEGIN
     INSERT INTO UsaStates_rtree (Id, XMin, YMin, XMax, YMax)
     VALUES (
         NEW.Id,
-        SP_XMin(NEW.Geometry),
-        SP_YMin(NEW.Geometry),
-        SP_XMax(NEW.Geometry),
-        SP_YMax(NEW.Geometry));
+        ST_XMin(NEW.Geometry),
+        ST_YMin(NEW.Geometry),
+        ST_XMax(NEW.Geometry),
+        ST_YMax(NEW.Geometry));
 END;
 
 CREATE TRIGGER UsaStates_update AFTER UPDATE OF geometry ON UsaStates
 BEGIN
     UPDATE UsaStates_rtree
-    SET XMin = SP_XMin(NEW.Geometry),
-        XMax = SP_XMax(NEW.Geometry),
-        YMin = SP_YMin(NEW.Geometry),
-        YMax = SP_YMax(NEW.Geometry)
+    SET XMin = ST_XMin(NEW.Geometry),
+        XMax = ST_XMax(NEW.Geometry),
+        YMin = ST_YMin(NEW.Geometry),
+        YMax = ST_YMax(NEW.Geometry)
     WHERE Id = NEW.Id;
 END;
 
@@ -69,19 +69,19 @@ BEGIN
     INSERT INTO UsaCities_rtree (Id, XMin, YMin, XMax, YMax)
     VALUES (
         NEW.Id,
-        SP_XMin(NEW.Geometry),
-        SP_YMin(NEW.Geometry),
-        SP_XMax(NEW.Geometry),
-        SP_YMax(NEW.Geometry));
+        ST_XMin(NEW.Geometry),
+        ST_YMin(NEW.Geometry),
+        ST_XMax(NEW.Geometry),
+        ST_YMax(NEW.Geometry));
 END;
 
 CREATE TRIGGER UsaCities_update AFTER UPDATE OF geometry ON UsaCities
 BEGIN
     UPDATE UsaCities_rtree
-    SET XMin = SP_XMin(NEW.Geometry),
-        XMax = SP_XMax(NEW.Geometry),
-        YMin = SP_YMin(NEW.Geometry),
-        YMax = SP_YMax(NEW.Geometry)
+    SET XMin = ST_XMin(NEW.Geometry),
+        XMax = ST_XMax(NEW.Geometry),
+        YMin = ST_YMin(NEW.Geometry),
+        YMax = ST_YMax(NEW.Geometry)
     WHERE Id = NEW.Id;
 END;
 

--- a/src/SQuan.Helpers.SQLiteSpatial/SQLiteSpatialExtension.cs
+++ b/src/SQuan.Helpers.SQLiteSpatial/SQLiteSpatialExtension.cs
@@ -92,6 +92,7 @@ public static class SQLiteSpatialExtensions
 		CreateGeometryGeometryFunction<int>(db.Handle, "ST_EqualsTopologically", (g, g2) => g?.EqualsTopologically(g2) ?? false ? 1 : 0);
 		CreateGeometryFunction<string?>(db.Handle, "ST_Envelope", (g) => g?.Envelope?.AsText());
 		CreateGeometryFunction<string?>(db.Handle, "ST_GeometryType", (g) => g?.GeometryType);
+		CreateSpatialIndexFunction<double?>(db.Handle, "ST_Height", (s) => s?.Height);
 		CreateGeometryFunction<string?>(db.Handle, "ST_IsRectangle", (g) => g?.InteriorPoint?.AsText());
 		CreateGeometryGeometryFunction<string?>(db.Handle, "ST_Intersection", (g, g2) => g?.Intersection(g2)?.AsText());
 		CreateGeometryGeometryFunction<int>(db.Handle, "ST_Intersects", (g, g2) => g?.Intersects(g2) ?? false ? 1 : 0);
@@ -107,17 +108,14 @@ public static class SQLiteSpatialExtensions
 		CreateGeometryGeometryFunction<string?>(db.Handle, "ST_SymmetricDifference", (g, g2) => g?.SymmetricDifference(g2)?.ToText());
 		CreateGeometryGeometryFunction<int>(db.Handle, "ST_Touches", (g, g2) => g?.Touches(g2) ?? false ? 1 : 0);
 		CreateGeometryGeometryFunction<string?>(db.Handle, "ST_Union", (g, g2) => g?.Union(g2)?.ToText());
+		CreateSpatialIndexFunction<double?>(db.Handle, "ST_Width", (s) => s?.Width);
 		CreateGeometryGeometryFunction<int>(db.Handle, "ST_Within", (g, g2) => g?.Within(g2) ?? false ? 1 : 0);
-		CreateGeometryGeometryFunction<double?>(db.Handle, "ST_X", (g, g2) => g?.Centroid.X);
-		CreateGeometryGeometryFunction<double?>(db.Handle, "ST_Y", (g, g2) => g?.Centroid.Y);
-		CreateSpatialIndexFunction<double?>(db.Handle, "SP_Height", (s) => s?.Height);
-		CreateSpatialIndexFunction<double?>(db.Handle, "SP_Width", (s) => s?.Width);
-		CreateSpatialIndexFunction<double?>(db.Handle, "SP_X", (s) => s?.CenterX);
-		CreateSpatialIndexFunction<double?>(db.Handle, "SP_XMin", (s) => s?.X1);
-		CreateSpatialIndexFunction<double?>(db.Handle, "SP_XMax", (s) => s?.X2);
-		CreateSpatialIndexFunction<double?>(db.Handle, "SP_Y", (s) => s?.CenterY);
-		CreateSpatialIndexFunction<double?>(db.Handle, "SP_YMin", (s) => s?.Y1);
-		CreateSpatialIndexFunction<double?>(db.Handle, "SP_YMax", (s) => s?.Y2);
+		CreateGeometryFunction<double?>(db.Handle, "ST_X", (g) => g?.Centroid.X);
+		CreateSpatialIndexFunction<double?>(db.Handle, "ST_XMax", (s) => s?.X2);
+		CreateSpatialIndexFunction<double?>(db.Handle, "ST_XMin", (s) => s?.X1);
+		CreateGeometryFunction<double?>(db.Handle, "ST_Y", (g) => g?.Centroid.Y);
+		CreateSpatialIndexFunction<double?>(db.Handle, "ST_YMax", (s) => s?.Y2);
+		CreateSpatialIndexFunction<double?>(db.Handle, "ST_YMin", (s) => s?.Y1);
 	}
 
 	/// <summary>

--- a/src/SQuan.Helpers.UnitTests/SQLiteSpatialTests.cs
+++ b/src/SQuan.Helpers.UnitTests/SQLiteSpatialTests.cs
@@ -1,4 +1,6 @@
-﻿using SQuan.Helpers.SQLiteSpatial;
+﻿// SQLiteSpatialTests.cs
+
+using SQuan.Helpers.SQLiteSpatial;
 
 namespace SQuan.Helpers.Maui.UnitTests;
 
@@ -8,7 +10,7 @@ public class SQLiteSpatialTests
 	[InlineData("SELECT ST_Point(3,4)", "POINT (3 4)")]
 	[InlineData("SELECT ST_Envelope(ST_Buffer('POINT (5 5)', 5))", "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))")]
 	[InlineData("SELECT ST_Intersection('LINESTRING(0 0,10 10)','LINESTRING(0 10,10 0)')", "POINT (5 5)")]
-	public void SQLiteSpatial_SpatialQuery_ReturnsExpectedGeometry(string sqlQuery, string expectedWkt)
+	public void SQLiteSpatial_GeometryQuery_ReturnsExpectedGeometry(string sqlQuery, string expectedWkt)
 	{
 		SQLiteSpatialConnection db = new(":memory:");
 		string? actualWkt = db.ExecuteScalar<string?>(sqlQuery);
@@ -19,7 +21,16 @@ public class SQLiteSpatialTests
 	[Theory]
 	[InlineData("SELECT ST_Distance('POINT(0 0)','POINT(3 4)')", 5)]
 	[InlineData("SELECT ST_Area(ST_Envelope(ST_Buffer('POINT (5 5)', 5)))", 100)]
-	public void SQLiteSpatial_SpatialQuery_ReturnsExpectedNumber(string sqlQuery, double expectedResult)
+	[InlineData("SELECT ST_Length(ST_Envelope(ST_Buffer('POINT (5 5)', 5)))", 40)]
+	[InlineData("SELECT ST_Width(ST_Buffer('POINT (40 30)', 5))", 10)]
+	[InlineData("SELECT ST_Height(ST_Buffer('POINT (40 30)', 5))", 10)]
+	[InlineData("SELECT ST_X('POINT (40 30)')", 40)]
+	[InlineData("SELECT ST_Y('POINT (40 30)')", 30)]
+	[InlineData("SELECT ST_XMin(ST_Buffer('POINT (40 30)', 5))", 35)]
+	[InlineData("SELECT ST_XMax(ST_Buffer('POINT (40 30)', 5))", 45)]
+	[InlineData("SELECT ST_YMin(ST_Buffer('POINT (40 30)', 5))", 25)]
+	[InlineData("SELECT ST_YMax(ST_Buffer('POINT (40 30)', 5))", 35)]
+	public void SQLiteSpatial_NumericQuery_ReturnsExpectedNumber(string sqlQuery, double expectedResult)
 	{
 		SQLiteSpatialConnection db = new(":memory:");
 		double? actualResult = db.ExecuteScalar<double?>(sqlQuery);
@@ -27,4 +38,25 @@ public class SQLiteSpatialTests
 		Assert.Equal(expectedResult, actualResult);
 	}
 
+	[Theory]
+	[InlineData("SELECT ST_IsValid('POINT (40 30)')", 1)]
+	[InlineData("SELECT ST_IsRectangle(ST_Buffer('POINT (40 30)', 5))", 0)]
+	[InlineData("SELECT ST_IsRectangle(ST_Envelope(ST_Buffer('POINT (40 30)', 5)))", 1)]
+	public void SQLiteSpatial_BooleanQuery_ReturnsExpectedBoolean(string sqlQuery, int expectedResult)
+	{
+		SQLiteSpatialConnection db = new(":memory:");
+		int? actualResult = db.ExecuteScalar<int?>(sqlQuery);
+		Assert.NotNull(actualResult);
+		Assert.Equal(expectedResult, actualResult);
+	}
+
+	[Theory]
+	[InlineData("SELECT ST_SRID(ST_SetSRID('POINT (40 30)', 4326))", 4326)]
+	public void SQLiteSpatial_IntegerQuery_ReturnsExpectedInteger(string sqlQuery, int expectedResult)
+	{
+		SQLiteSpatialConnection db = new(":memory:");
+		int? actualResult = db.ExecuteScalar<int?>(sqlQuery);
+		Assert.NotNull(actualResult);
+		Assert.Equal(expectedResult, actualResult);
+	}
 }


### PR DESCRIPTION
#106 

Summary:
 - SP_MinX => ST_MinX
 - SP_MinY => ST_MinY
 - SP_MaxX => ST_MaxX
 - SP_MaxY => ST_MaxY
 - SP_Width => ST_Width
 - SP_Height => ST_Height
 - Dropped SP_X and SP_Y
 - Corrected ST_X and ST_Y implementation
 - Increase code coverage of unit tests