### PR TITLE
Support High DPI and tap gestures (instead of point gestures)

### DIFF
--- a/samples/SQuan.Helpers.Sample/Models/MapViewEventArgs.cs
+++ b/samples/SQuan.Helpers.Sample/Models/MapViewEventArgs.cs
@@ -1,0 +1,30 @@
+﻿// MapViewEventArgs.cs
+
+namespace SQuan.Helpers.Sample;
+
+/// <summary>
+/// Provides data for events related to map view interactions.
+/// </summary>
+public class MapViewEventArgs : EventArgs
+{
+	/// <summary>
+	/// Gets or sets the point in view coordinates where the event occurred.
+	/// </summary>
+	public Point ViewPoint { get; set; }
+
+	/// <summary>
+	/// Gets or sets the corresponding point in map coordinates.
+	/// </summary>
+	public Point MapPoint { get; set; }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="MapViewEventArgs"/> class.
+	/// </summary>
+	/// <param name="viewPoint">The point in view coordinates where the event occurred.</param>
+	/// <param name="mapPoint">The corresponding point in map coordinates.</param>
+	public MapViewEventArgs(Point viewPoint, Point mapPoint)
+	{
+		ViewPoint = viewPoint;
+		MapPoint = mapPoint;
+	}
+}

--- a/samples/SQuan.Helpers.Sample/Pages/SpatialPage.xaml
+++ b/samples/SQuan.Helpers.Sample/Pages/SpatialPage.xaml
@@ -10,7 +10,7 @@
         <local:MapView
             x:Name="mapView"
             PaintSurface="mapView_PaintSurface"
-            Pressed="OnMapPressed" />
+            Tapped="OnMapTapped" />
         <Grid
             Margin="40"
             HorizontalOptions="End"

--- a/samples/SQuan.Helpers.Sample/Pages/SpatialPage.xaml.cs
+++ b/samples/SQuan.Helpers.Sample/Pages/SpatialPage.xaml.cs
@@ -112,40 +112,13 @@ AND    c.Id = r.Id");
 		System.Diagnostics.Trace.WriteLine($"Drawn {statesDrawn} states and {citiesDrawn} cities.");
 	}
 
-	public int DrawSpatialData(SKCanvas canvas, string sqlQuery)
-	{
-		int count = 0;
-		var items = db.Query<SpatialData>(sqlQuery);
-		foreach (var item in items)
-		{
-			mapView.DrawMapGeometry(canvas, SQLiteSpatialExtensions.ToGeometry(item.Geometry), item.Name, Color.FromArgb(item.Color));
-			count++;
-		}
-		return count;
-	}
+	int DrawSpatialData(SKCanvas canvas, string sqlQuery)
+		=> db.Query<SpatialData>(sqlQuery)
+			.Select(item => mapView.DrawMapGeometry(canvas, SQLiteSpatialExtensions.ToGeometry(item.Geometry), item.Name, Color.FromArgb(item.Color)))
+			.Count();
 
-	void OnReset(object sender, EventArgs e)
-	{
-		mapView.SetMapExtent(-125, 24.3, -66.9, 49.4); // USA extent
-	}
-
-	void OnZoomIn(object sender, EventArgs e)
-	{
-		mapView.Zoom(2.0);
-	}
-
-	void OnZoomOut(object sender, EventArgs e)
-	{
-		mapView.Zoom(0.5);
-	}
-
-	void OnMapPressed(object sender, PointEventArgs e)
-	{
-		mapView.SetMapExtent(
-			e.MapPoint.X - mapView.MapExtent.Width / 2,
-			e.MapPoint.Y - mapView.MapExtent.Height / 2,
-			e.MapPoint.X + mapView.MapExtent.Width / 2,
-			e.MapPoint.Y + mapView.MapExtent.Height / 2);
-		mapView.InvalidateSurface();
-	}
+	void OnReset(object sender, EventArgs e) => mapView.SetMapExtent(-125, 24.3, -66.9, 49.4);
+	void OnZoomIn(object sender, EventArgs e) => mapView.Zoom(2.0);
+	void OnZoomOut(object sender, EventArgs e) => mapView.Zoom(0.5);
+	void OnMapTapped(object sender, MapViewEventArgs e) => mapView.PanTo(e.MapPoint);
 }


### PR DESCRIPTION
#120 

 - When drawing to the SkiaSharp SKCanvas make sure dpiScale is applied to map "View" coordinates to native Skia coordinates
 - Tap gestures covers both Touch (i.e. Android) and Pointer (i.e. desktop Windows)
 - Refactor the code