### PR TITLE
Emit initial BindableProperty change events for non-default initializers

### DIFF
--- a/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/BindablePropertyGenerator.cs
+++ b/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/BindablePropertyGenerator.cs
@@ -181,10 +181,13 @@ partial class {className}
 		Is{propertyName}CreatingDefaultValue = true;
 		var result = {propertyName};
 		Is{propertyName}CreatingDefaultValue = false;
-		On{propertyName}Changing(result);
-		On{propertyName}Changing(default({typeName}), result);
-		On{propertyName}Changed(result);
-		On{propertyName}Changed(default({typeName}), result);
+		if (!EqualityComparer<{typeName}>.Default.Equals(result, default({typeName})))
+		{{
+			On{propertyName}Changing(result);
+			On{propertyName}Changing(default({typeName}), result);
+			On{propertyName}Changed(result);
+			On{propertyName}Changed(default({typeName}), result);
+		}}
 		return result;
 	}}
 

--- a/src/SQuan.Helpers.UnitTests/CustomContentView.cs
+++ b/src/SQuan.Helpers.UnitTests/CustomContentView.cs
@@ -1,5 +1,6 @@
 ﻿// CustomContentView.cs
 
+using System.Globalization;
 using SQuan.Helpers.Maui.Mvvm;
 
 namespace SQuan.Helpers.Maui.UnitTests;
@@ -7,9 +8,9 @@ namespace SQuan.Helpers.Maui.UnitTests;
 public partial class CustomContentView : ContentView
 {
 	[BindableProperty] public partial int Magic { get; set; } = 42;
+	[BindableProperty] public partial CultureInfo? Culture { get; set; }
 	public int MagicChangedCount { get; private set; } = 0;
-	partial void OnMagicChanged(int oldValue, int newValue)
-	{
-		MagicChangedCount++;
-	}
+	public int CultureChangedCount { get; private set; } = 0;
+	partial void OnMagicChanged(int value) => MagicChangedCount++;
+	partial void OnCultureChanged(CultureInfo? value) => CultureChangedCount++;
 }

--- a/src/SQuan.Helpers.UnitTests/MvvmUnitTests.cs
+++ b/src/SQuan.Helpers.UnitTests/MvvmUnitTests.cs
@@ -1,20 +1,42 @@
 ﻿// MvvmUnitTests.cs
 
+using System.Globalization;
 using SQuan.Helpers.Maui.UnitTests.Mocks;
 
 namespace SQuan.Helpers.Maui.UnitTests;
 
 public class MvvmUnitTests
 {
+	[Theory]
+	[InlineData(0, 0)]
+	[InlineData(42, 1)]
+	public void OnPropertyChanged_WhenBindablePropertyInitialized_EventCountIsCorrect(int initializer, int expectedChangeCount)
+	{
+		DispatcherProvider.SetCurrent(new MockDispatcherProvider());
+		var view = new CustomContentView() { Magic = initializer };
+		Assert.Equal(initializer, view.Magic);
+		Assert.Equal(expectedChangeCount, view.MagicChangedCount);
+		view.Magic++;
+		Assert.Equal(initializer + 1, view.Magic);
+		Assert.Equal(expectedChangeCount + 1, view.MagicChangedCount);
+	}
+
 	[Fact]
-	public void OnPropertyChanged_WhenBindablePropertyInitialized_EventCountIsCorrect()
+	public void DefaultCultureInitializer_EventCountIsCorrect()
 	{
 		DispatcherProvider.SetCurrent(new MockDispatcherProvider());
 		var view = new CustomContentView();
-		Assert.Equal(42, view.Magic);
-		Assert.Equal(1, view.MagicChangedCount);
-		view.Magic = 100;
-		Assert.Equal(100, view.Magic);
-		Assert.Equal(2, view.MagicChangedCount);
+		Assert.Null(view.Culture);
+		Assert.Equal(0, view.CultureChangedCount);
+	}
+
+	[Theory]
+	[InlineData("fr-FR", 1)]
+	public void NonDefaultCultureInitializer_EventCountIsCorrect(string cultureName, int expectedCount)
+	{
+		DispatcherProvider.SetCurrent(new MockDispatcherProvider());
+		var view = new CustomContentView() { Culture = new CultureInfo(cultureName) };
+		Assert.Equal(cultureName, view.Culture?.Name);
+		Assert.Equal(expectedCount, view.CultureChangedCount);
 	}
 }


### PR DESCRIPTION
#122 

 - Add EqualityComparer guard to only emit property change events for non-default initializers
 - Update xUnit unit test to cover both default and non-default initializers