### PR TITLE
Introduce BPExtrasAttribute

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,15 +18,15 @@
     <NuGetAuditMode>all</NuGetAuditMode>
 
     <!-- MAUI Specific -->
-    <MauiVersion>10.0.31</MauiVersion>
-    <MauiPackageVersion>10.0.31</MauiPackageVersion>
+    <MauiVersion>10.0.41</MauiVersion>
+    <MauiPackageVersion>10.0.41</MauiPackageVersion>
     <NextMauiPackageVersion>10.0.0</NextMauiPackageVersion>
     <MauiStrictXamlCompilation>true</MauiStrictXamlCompilation>
     <SkipValidateMauiImplicitPackageReferences>true</SkipValidateMauiImplicitPackageReferences>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
 
     <!-- CommunityToolkit.Maui -->
-    <NoWarn>$(NoWarn);MCTEXP001;CS0436</NoWarn>
+    <NoWarn>$(NoWarn);MCTEXP001</NoWarn>
 
     <!-- https://learn.microsoft.com/dotnet/core/deploying/native-aot/?tabs=net8plus%2Cwindows -->
     <StripSymbols>false</StripSymbols>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,13 +20,20 @@
     <!-- MAUI Specific -->
     <MauiVersion>10.0.41</MauiVersion>
     <MauiPackageVersion>10.0.41</MauiPackageVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>10.0.3</MicrosoftExtensionsLoggingDebugVersion>
     <NextMauiPackageVersion>10.0.0</NextMauiPackageVersion>
     <MauiStrictXamlCompilation>true</MauiStrictXamlCompilation>
     <SkipValidateMauiImplicitPackageReferences>true</SkipValidateMauiImplicitPackageReferences>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
 
-    <!-- CommunityToolkit.Maui -->
+    <!-- CommunityToolkits -->
+    <CommunityToolkitMauiVersion>14.0.1</CommunityToolkitMauiVersion>
+    <CommunityToolkitMauiMarkupVersion>7.0.0</CommunityToolkitMauiMarkupVersion>
+    <CommunityToolkitMvvmVersion>8.4.0</CommunityToolkitMvvmVersion>
     <NoWarn>$(NoWarn);MCTEXP001</NoWarn>
+
+    <!-- GitVersion -->
+    <GitVersionMsBuildVersion>6.4.0</GitVersionMsBuildVersion>
 
     <!-- https://learn.microsoft.com/dotnet/core/deploying/native-aot/?tabs=net8plus%2Cwindows -->
     <StripSymbols>false</StripSymbols>

--- a/samples/SQuan.Helpers.Sample/Extensions/EvalExtension.cs
+++ b/samples/SQuan.Helpers.Sample/Extensions/EvalExtension.cs
@@ -1,7 +1,8 @@
 ﻿// EvalExtension.cs
 
 using CommunityToolkit.Maui.Converters;
-using SQuan.Helpers.Maui.Mvvm;
+using CommunityToolkit.Maui.Markup;
+using BindablePropertyAttribute = CommunityToolkit.Maui.BindablePropertyAttribute;
 
 namespace SQuan.Helpers.Sample;
 
@@ -16,52 +17,77 @@ namespace SQuan.Helpers.Sample;
 [RequireService([typeof(IReferenceProvider), typeof(IProvideValueTarget)])]
 public partial class EvalExtension : BindableObject, IMarkupExtension<BindingBase>
 {
-	readonly MultiMathExpressionConverter multiMathExpressionConverter = new MultiMathExpressionConverter();
+	static MultiMathExpressionConverter multiMathExpressionConverter = new MultiMathExpressionConverter();
 
 	/// <summary>Gets or sets the mathematical expression to evaluate.</summary>
-	[BindableProperty, NotifyPropertyChangedFor(nameof(ReturnValue))] public partial string Expression { get; set; } = string.Empty;
+	[BindableProperty] public partial string Expression { get; set; } = string.Empty;
 
 	/// <summary>Gets or sets the value of variable X0 in the expression.</summary>
-	[BindableProperty, NotifyPropertyChangedFor(nameof(ReturnValue))] public partial object? X0 { get; set; } = null;
+	[BindableProperty] public partial object? X0 { get; set; } = null;
 
 	/// <summary>Gets or sets the value of variable X1 in the expression.</summary>
-	[BindableProperty, NotifyPropertyChangedFor(nameof(ReturnValue))] public partial object? X1 { get; set; } = null;
+	[BindableProperty] public partial object? X1 { get; set; } = null;
 
 	/// <summary>Gets or sets the value of variable X2 in the expression.</summary>
-	[BindableProperty, NotifyPropertyChangedFor(nameof(ReturnValue))] public partial object? X2 { get; set; } = null;
+	[BindableProperty] public partial object? X2 { get; set; } = null;
 
 	/// <summary>Gets or sets the value of variable X3 in the expression.</summary>
-	[BindableProperty, NotifyPropertyChangedFor(nameof(ReturnValue))] public partial object? X3 { get; set; } = null;
+	[BindableProperty] public partial object? X3 { get; set; } = null;
 
 	/// <summary>Gets or sets the value of variable X4 in the expression.</summary>
-	[BindableProperty, NotifyPropertyChangedFor(nameof(ReturnValue))] public partial object? X4 { get; set; } = null;
+	[BindableProperty] public partial object? X4 { get; set; } = null;
 
 	/// <summary>Gets or sets the value of variable X5 in the expression.</summary>
-	[BindableProperty, NotifyPropertyChangedFor(nameof(ReturnValue))] public partial object? X5 { get; set; } = null;
+	[BindableProperty] public partial object? X5 { get; set; } = null;
+
+	/// <summary>Gets or sets the expected return type of the evaluated expression.</summary>
+	[BindableProperty] public partial Type? ReturnType { get; set; }
 
 	/// <summary>Gets the result of evaluating the mathematical expression.</summary>
-	public object? ReturnValue
-	{
-		get
-		{
-			if (string.IsNullOrEmpty(this.Expression))
-			{
-				return null;
-			}
+	[BindableProperty]
+	public partial object? ReturnValue { get; set; }
 
-			try
+
+	public EvalExtension()
+	{
+		this.SetBinding(
+			ReturnValueProperty,
+			new MultiBinding
 			{
-				return multiMathExpressionConverter.Convert(
-					new object?[] { X0, X1, X2, X3, X4, X5 },
-					typeof(object),
-					this.Expression,
-					System.Globalization.CultureInfo.InvariantCulture);
-			}
-			catch (Exception ex)
-			{
-				return $"Exception: {ex.Message}";
-			}
-		}
+				Bindings =
+				{
+					new Binding("X0", BindingMode.OneWay, source: this),
+					new Binding("X1", BindingMode.OneWay, source: this),
+					new Binding("X2", BindingMode.OneWay, source: this),
+					new Binding("X3", BindingMode.OneWay, source: this),
+					new Binding("X4", BindingMode.OneWay, source: this),
+					new Binding("X5", BindingMode.OneWay, source: this),
+					new Binding("Expression", BindingMode.OneWay, source: this),
+				},
+				Converter = new FuncMultiConverter<object?, object?[]>(static (values) =>
+				{
+					if (values is not null
+						&& values.Length == 7
+						&& values[6] is string expression
+						&& !string.IsNullOrEmpty(expression))
+					{
+						var xValues = values.Take(6).ToArray();
+						try
+						{
+							return multiMathExpressionConverter.Convert(
+								xValues,
+								typeof(object),
+								expression,
+								System.Globalization.CultureInfo.InvariantCulture);
+						}
+						catch (Exception ex)
+						{
+							return $"Exception: {ex.Message}";
+						}
+					}
+					return null;
+				})
+			});
 	}
 
 	/// <summary>
@@ -79,6 +105,12 @@ public partial class EvalExtension : BindableObject, IMarkupExtension<BindingBas
 			{
 				this.SetBinding(BindableObject.BindingContextProperty, static (BindableObject t) => t.BindingContext, BindingMode.OneWay, source: targetObject);
 			}
+			this.ReturnType ??= provideValueTarget.TargetProperty switch
+			{
+				BindableProperty tbp => tbp.ReturnType,
+				System.Reflection.PropertyInfo pi => pi.PropertyType,
+				_ => null
+			};
 		}
 		return BindingBase.Create(static (EvalExtension ctx) => ctx.ReturnValue, BindingMode.OneWay, source: this);
 	}

--- a/samples/SQuan.Helpers.Sample/Pages/CountPage.xaml.cs
+++ b/samples/SQuan.Helpers.Sample/Pages/CountPage.xaml.cs
@@ -1,13 +1,21 @@
+// CountPage.xaml.cs
+
 using CommunityToolkit.Maui.Markup;
-using SQuan.Helpers.Maui.Mvvm;
+using BindablePropertyAttribute = CommunityToolkit.Maui.BindablePropertyAttribute;
+using BPExtrasAttribute = SQuan.Helpers.Maui.Mvvm.BPExtrasAttribute;
 using RelayCommandAttribute = CommunityToolkit.Mvvm.Input.RelayCommandAttribute;
 
 namespace SQuan.Helpers.Sample;
 
 public partial class CountPage : ContentPage
 {
-	// Our syntax is similar to CommunityToolkit.Mvvm
-	[ObservableProperty] public partial int Count { get; set; } = 0;
+	[BindableProperty(PropertyChangedMethodName = nameof(OnCountChanged)), BPExtras]
+	public partial int Count { get; set; } = 0;
+
+	partial void OnCountChanged(int oldValue, int newValue)
+	{
+		System.Diagnostics.Trace.WriteLine($"Count changed from {oldValue} to {newValue}");
+	}
 
 	public CountPage()
 	{

--- a/samples/SQuan.Helpers.Sample/Pages/SearchPage.xaml.cs
+++ b/samples/SQuan.Helpers.Sample/Pages/SearchPage.xaml.cs
@@ -3,6 +3,7 @@
 using System.Dynamic;
 using SQuan.Helpers.Maui;
 using SQuan.Helpers.Maui.Mvvm;
+using BindablePropertyAttribute = CommunityToolkit.Maui.BindablePropertyAttribute;
 
 namespace SQuan.Helpers.Sample;
 
@@ -10,9 +11,16 @@ namespace SQuan.Helpers.Sample;
 
 public partial class SearchPage : ContentPage
 {
-	[BindableProperty] public partial string SearchText { get; set; } = "Statue of Liberty";
-	[BindableProperty, NotifyPropertyChangedFor(nameof(IsNotSearching))] public partial bool IsSearching { get; internal set; } = false;
+	[BindableProperty]
+	public partial string SearchText { get; set; } = "Statue of Liberty";
+
+	[BindableProperty(PropertyChangedMethodName = nameof(IsSearchingChanged)), BPExtras]
+	public partial bool IsSearching { get; internal set; } = false;
+	partial void IsSearchingChanged(bool value)
+		=> OnPropertyChanged(nameof(IsNotSearching));
+
 	public bool IsNotSearching => !IsSearching;
+
 	public ObservableList<SearchResult> Results { get; } = [];
 	CancellationTokenSource? cts;
 

--- a/samples/SQuan.Helpers.Sample/SQuan.Helpers.Sample.csproj
+++ b/samples/SQuan.Helpers.Sample/SQuan.Helpers.Sample.csproj
@@ -63,7 +63,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="GitVersion.MsBuild" Version="6.4.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="14.0.0" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="14.0.1" />
 		<PackageReference Include="CommunityToolkit.Maui.Markup" Version="7.0.0" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />

--- a/samples/SQuan.Helpers.Sample/SQuan.Helpers.Sample.csproj
+++ b/samples/SQuan.Helpers.Sample/SQuan.Helpers.Sample.csproj
@@ -62,13 +62,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="GitVersion.MsBuild" Version="6.4.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="14.0.1" />
-		<PackageReference Include="CommunityToolkit.Maui.Markup" Version="7.0.0" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+		<PackageReference Include="GitVersion.MsBuild" Version="$(GitVersionMsBuildVersion)" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="$(CommunityToolkitMauiVersion)" />
+		<PackageReference Include="CommunityToolkit.Maui.Markup" Version="$(CommunityToolkitMauiMarkupVersion)" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="$(CommunityToolkitMvvmVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Essentials" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(MicrosoftExtensionsLoggingDebugVersion)" />
 		<PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="3.119.2-preview.1" />
 	</ItemGroup>
 

--- a/samples/SQuan.Helpers.Sample/Views/BalanceView.cs
+++ b/samples/SQuan.Helpers.Sample/Views/BalanceView.cs
@@ -1,6 +1,8 @@
-﻿using System.Globalization;
+﻿// BalanceView.cs
+
+using System.Globalization;
 using CommunityToolkit.Maui.Markup;
-using SQuan.Helpers.Maui.Mvvm;
+using BindablePropertyAttribute = CommunityToolkit.Maui.BindablePropertyAttribute;
 
 namespace SQuan.Helpers.Sample;
 

--- a/samples/SQuan.Helpers.Sample/Views/CardView.xaml.cs
+++ b/samples/SQuan.Helpers.Sample/Views/CardView.xaml.cs
@@ -1,5 +1,7 @@
+// CardView.xaml.cs
+
 using CommunityToolkit.Maui.Markup;
-using SQuan.Helpers.Maui.Mvvm;
+using BindablePropertyAttribute = CommunityToolkit.Maui.BindablePropertyAttribute;
 
 namespace SQuan.Helpers.Sample;
 

--- a/src/SQuan.Helpers.Maui.Localization/SQuan.Helpers.Maui.Localization.csproj
+++ b/src/SQuan.Helpers.Maui.Localization/SQuan.Helpers.Maui.Localization.csproj
@@ -64,7 +64,7 @@
   </Target>
 
   <ItemGroup Label="Package">
-    <PackageReference Include="GitVersion.MsBuild" Version="6.4.0" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="$(GitVersionMsBuildVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/BPExtrasGenerator.cs
+++ b/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/BPExtrasGenerator.cs
@@ -73,7 +73,6 @@ public class BPExtrasGenerator : IIncrementalGenerator
 			var namespaceName = classSymbol.ContainingNamespace.ToDisplayString();
 			var propertyName = propertySymbol.Name;
 			var typeName = propertySymbol.Type.ToDisplayString();
-			PropertyDeclarationSyntax propertySyntax = (propertySymbol.DeclaringSyntaxReferences[0].GetSyntax() as PropertyDeclarationSyntax)!;
 
 			bool hasPropertyChangedMethod = false;
 			string propertyChangedMethodName = string.Empty;

--- a/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/BPExtrasGenerator.cs
+++ b/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/BPExtrasGenerator.cs
@@ -148,7 +148,7 @@ public class BPExtrasGenerator : IIncrementalGenerator
 						{{staticWrappers}}
 					}
 					""";
-				spc.AddSource($"{bareClassName}_{propertyName}_BPExtras.g.cs", SourceText.From(source, Encoding.UTF8));
+				spc.AddSource($"{namespaceName}_{bareClassName}_{propertyName}_BPExtras.g.cs", SourceText.From(source, Encoding.UTF8));
 			}
 		});
 	}

--- a/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/BPExtrasGenerator.cs
+++ b/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/BPExtrasGenerator.cs
@@ -1,0 +1,157 @@
+﻿// BPExtrasGenerator.cs
+
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using SQuan.Helpers.Maui.Mvvm.SourceGenerators.Helpers;
+
+namespace SQuan.Helpers.Maui.Mvvm.SourceGenerators;
+
+/// <summary>
+/// Generates static wrapper methods for instance or partial methods defined in a class with properties decorated with
+/// both CommunityToolkit.Maui's [BindableProperty] and SQuan.Helpers.Maui.Mvvm [BPExtras] attributes, enabling simpler integration
+/// with the BindableProperty's PropertyChanged and PropertyChanging callbacks without needing to define static methods manually.
+/// </summary>
+[Generator]
+public class BPExtrasGenerator : IIncrementalGenerator
+{
+	/// <summary>
+	/// Initializes the incremental source generator by configuring the syntax provider to identify properties with
+	/// specific attributes and registering the source output for code generation.
+	/// </summary>
+	/// <param name="context">The context for generator initialization, providing access to the syntax provider and mechanisms
+	/// for registering source outputs.</param>
+	public void Initialize(IncrementalGeneratorInitializationContext context)
+	{
+		var properties = context.SyntaxProvider
+			.CreateSyntaxProvider(
+				predicate: static (node, _)
+					=> node is PropertyDeclarationSyntax propertyDeclaration
+						&& propertyDeclaration.AttributeLists.Count > 0
+						&& propertyDeclaration.Modifiers.Count > 0
+						&& propertyDeclaration.Modifiers.IndexOf(SyntaxKind.PartialKeyword) != -1,
+				transform: static (ctx, _) =>
+				{
+					var propertySyntax = (PropertyDeclarationSyntax)ctx.Node;
+					var propertySymbol = ctx.SemanticModel.GetDeclaredSymbol(propertySyntax) as IPropertySymbol;
+					if (propertySymbol is null)
+					{
+						return null;
+					}
+
+					bool hasBindablePropertyExtrasAttribute = false;
+					bool hasBindablePropertyAttribute = false;
+					foreach (var attr in propertySymbol.GetAttributes())
+					{
+						if (attr.AttributeClass?.Name == "CommunityToolkit.Maui.BindablePropertyAttribute" ||
+							attr.AttributeClass?.ToDisplayString() == "CommunityToolkit.Maui.BindablePropertyAttribute")
+						{
+							hasBindablePropertyAttribute = true;
+							continue;
+						}
+
+						if (attr.AttributeClass?.Name == "SQuan.Helpers.Maui.Mvvm.BPExtrasAttribute" ||
+							attr.AttributeClass?.ToDisplayString() == "SQuan.Helpers.Maui.Mvvm.BPExtrasAttribute")
+						{
+							hasBindablePropertyExtrasAttribute = true;
+							continue;
+						}
+					}
+
+					return (hasBindablePropertyAttribute && hasBindablePropertyExtrasAttribute) ? propertySymbol : null;
+				})
+			.Where(static symbol => symbol is not null);
+
+		context.RegisterSourceOutput(properties, (spc, propertySymbol) =>
+		{
+			var propertyAttributes = propertySymbol!.GetAttributes();
+			var classSymbol = propertySymbol!.ContainingType;
+			var className = classSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+			var bareClassName = classSymbol.Name;
+			var namespaceName = classSymbol.ContainingNamespace.ToDisplayString();
+			var propertyName = propertySymbol.Name;
+			var typeName = propertySymbol.Type.ToDisplayString();
+			PropertyDeclarationSyntax propertySyntax = (propertySymbol.DeclaringSyntaxReferences[0].GetSyntax() as PropertyDeclarationSyntax)!;
+
+			bool hasPropertyChangedMethod = false;
+			string propertyChangedMethodName = string.Empty;
+			bool hasPropertyChangingMethod = false;
+			string propertyChangingMethodName = string.Empty;
+
+			foreach (var attr in propertyAttributes)
+			{
+				switch (attr.AttributeClass?.ToDisplayString())
+				{
+					case "CommunityToolkit.Maui.BindablePropertyAttribute":
+						if (attr.GetAttributeValueByName("PropertyChangedMethodName").Value is string changedMethodName && !string.IsNullOrEmpty(changedMethodName))
+						{
+							hasPropertyChangedMethod = true;
+							propertyChangedMethodName = changedMethodName;
+						}
+						if (attr.GetAttributeValueByName("PropertyChangingMethodName").Value is string changingMethodName && !string.IsNullOrEmpty(changingMethodName))
+						{
+							hasPropertyChangingMethod = true;
+							propertyChangingMethodName = changingMethodName;
+						}
+						break;
+				}
+			}
+
+			string staticWrappers = string.Empty;
+			bool hasStaticWrappers = false;
+
+			if (hasPropertyChangedMethod)
+			{
+				staticWrappers +=
+					$$"""
+						static void {{propertyChangedMethodName}}(BindableObject b, object o, object n)
+						{
+							(({{className}})b).{{propertyChangedMethodName}}(({{typeName}})o, ({{typeName}})n);
+							(({{className}})b).{{propertyChangedMethodName}}(({{typeName}})n);
+						}
+						partial void {{propertyChangedMethodName}}({{typeName}} oldValue, {{typeName}} newValue);
+						partial void {{propertyChangedMethodName}}({{typeName}} value);
+					""";
+				hasStaticWrappers = true;
+			}
+
+			if (hasPropertyChangingMethod)
+			{
+				staticWrappers +=
+					$$"""
+						static void {{propertyChangingMethodName}}(BindableObject b, object o, object n)
+						{
+							(({{className}})b).{{propertyChangingMethodName}}(({{typeName}})o, ({{typeName}})n);
+							(({{className}})b).{{propertyChangingMethodName}}(({{typeName}})n);
+						}
+						partial void {{propertyChangingMethodName}}({{typeName}} oldValue, {{typeName}} newValue);
+						partial void {{propertyChangingMethodName}}({{typeName}} value);
+					""";
+				hasStaticWrappers = true;
+			}
+
+			if (hasStaticWrappers)
+			{
+				var source =
+					$$"""
+					using System.ComponentModel;
+
+					// <auto-generated/>
+					#pragma warning disable
+					#nullable enable
+
+					namespace {{namespaceName}};
+
+					//[{GeneratedCodeAttribute}]
+					partial class {{className}}
+					{
+						{{staticWrappers}}
+					}
+					""";
+				spc.AddSource($"{bareClassName}_{propertyName}_BindablePropertyExtras.g.cs", SourceText.From(source, Encoding.UTF8));
+			}
+		});
+	}
+}

--- a/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/BPExtrasGenerator.cs
+++ b/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/BPExtrasGenerator.cs
@@ -105,7 +105,7 @@ public class BPExtrasGenerator : IIncrementalGenerator
 			{
 				staticWrappers +=
 					$$"""
-						static void {{propertyChangedMethodName}}(BindableObject b, object o, object n)
+						static void {{propertyChangedMethodName}}(Microsoft.Maui.Controls.BindableObject b, object o, object n)
 						{
 							(({{className}})b).{{propertyChangedMethodName}}(({{typeName}})o, ({{typeName}})n);
 							(({{className}})b).{{propertyChangedMethodName}}(({{typeName}})n);

--- a/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/BPExtrasGenerator.cs
+++ b/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/BPExtrasGenerator.cs
@@ -121,7 +121,7 @@ public class BPExtrasGenerator : IIncrementalGenerator
 			{
 				staticWrappers +=
 					$$"""
-						static void {{propertyChangingMethodName}}(BindableObject b, object o, object n)
+						static void {{propertyChangingMethodName}}(Microsoft.Maui.Controls.BindableObject b, object o, object n)
 						{
 							(({{className}})b).{{propertyChangingMethodName}}(({{typeName}})o, ({{typeName}})n);
 							(({{className}})b).{{propertyChangingMethodName}}(({{typeName}})n);
@@ -144,13 +144,12 @@ public class BPExtrasGenerator : IIncrementalGenerator
 
 					namespace {{namespaceName}};
 
-					//[{GeneratedCodeAttribute}]
 					partial class {{className}}
 					{
 						{{staticWrappers}}
 					}
 					""";
-				spc.AddSource($"{bareClassName}_{propertyName}_BindablePropertyExtras.g.cs", SourceText.From(source, Encoding.UTF8));
+				spc.AddSource($"{bareClassName}_{propertyName}_BPExtras.g.cs", SourceText.From(source, Encoding.UTF8));
 			}
 		});
 	}

--- a/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/SQuan.Helpers.Maui.Mvvm.SourceGenerators.csproj
+++ b/src/SQuan.Helpers.Maui.Mvvm.SourceGenerators/SQuan.Helpers.Maui.Mvvm.SourceGenerators.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="6.4.0" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="GitVersion.MsBuild" Version="$(GitVersionMsBuildVersion)" PrivateAssets="contentfiles;analyzers" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SQuan.Helpers.Maui.Mvvm/BPExtrasAttribute.cs
+++ b/src/SQuan.Helpers.Maui.Mvvm/BPExtrasAttribute.cs
@@ -1,0 +1,13 @@
+﻿// BPExtrasAttribute.cs
+
+namespace SQuan.Helpers.Maui.Mvvm;
+
+/// <summary>
+/// An attribute to supplement the CommunityToolkit.Mvvm.BindablePropertyAttribute 
+/// by instructing the BPExtrasGenerator source generator to generate additional static method
+/// wrappers for corresponding instance or partial methods.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public class BPExtrasAttribute : Attribute
+{
+}

--- a/src/SQuan.Helpers.Maui.Mvvm/BPExtrasAttribute.cs
+++ b/src/SQuan.Helpers.Maui.Mvvm/BPExtrasAttribute.cs
@@ -3,7 +3,7 @@
 namespace SQuan.Helpers.Maui.Mvvm;
 
 /// <summary>
-/// An attribute to supplement the CommunityToolkit.Mvvm.BindablePropertyAttribute 
+/// An attribute to supplement the CommunityToolkit.Maui.BindablePropertyAttribute 
 /// by instructing the BPExtrasGenerator source generator to generate additional static method
 /// wrappers for corresponding instance or partial methods.
 /// </summary>

--- a/src/SQuan.Helpers.Maui.Mvvm/SQuan.Helpers.Maui.Mvvm.csproj
+++ b/src/SQuan.Helpers.Maui.Mvvm/SQuan.Helpers.Maui.Mvvm.csproj
@@ -52,7 +52,7 @@
   </Target>
   
   <ItemGroup Label="Package">
-    <PackageReference Include="GitVersion.MsBuild" Version="6.4.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+    <PackageReference Include="GitVersion.MsBuild" Version="$(GitVersionMsBuildVersion)" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
     <None Include="..\SQuan.Helpers.Maui.Mvvm.SourceGenerators\bin\$(Configuration)\netstandard2.0\SQuan.Helpers.Maui.Mvvm.SourceGenerators.dll" PackagePath="analyzers\dotnet\roslyn4.0\cs" Pack="true" Visible="true" />
   </ItemGroup>
   

--- a/src/SQuan.Helpers.Maui.UnitTests/CustomContentView.cs
+++ b/src/SQuan.Helpers.Maui.UnitTests/CustomContentView.cs
@@ -2,15 +2,25 @@
 
 using System.Globalization;
 using SQuan.Helpers.Maui.Mvvm;
+using BindablePropertyAttribute = CommunityToolkit.Maui.BindablePropertyAttribute;
 
 namespace SQuan.Helpers.Maui.UnitTests;
 
 public partial class CustomContentView : ContentView
 {
-	[BindableProperty] public partial int Magic { get; set; } = 42;
-	[BindableProperty] public partial CultureInfo? Culture { get; set; }
-	public int MagicChangedCount { get; private set; } = 0;
-	public int CultureChangedCount { get; private set; } = 0;
+	[BindableProperty(PropertyChangedMethodName = nameof(OnMagicChanged))]
+	[BPExtras]
+	public partial int Magic { get; set; } = 42;
 	partial void OnMagicChanged(int value) => MagicChangedCount++;
+
+	[BindableProperty(PropertyChangedMethodName = nameof(OnCultureChanged))]
+	[BPExtras]
+	public partial CultureInfo? Culture { get; set; }
 	partial void OnCultureChanged(CultureInfo? value) => CultureChangedCount++;
+
+	[BindableProperty]
+	public partial int MagicChangedCount { get; private set; } = 0;
+
+	[BindableProperty]
+	public partial int CultureChangedCount { get; private set; } = 0;
 }

--- a/src/SQuan.Helpers.Maui/SQuan.Helpers.Maui.csproj
+++ b/src/SQuan.Helpers.Maui/SQuan.Helpers.Maui.csproj
@@ -68,7 +68,7 @@
 	</Target>
 
 	<ItemGroup Label="Package">
-		<PackageReference Include="GitVersion.MsBuild" Version="6.4.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+		<PackageReference Include="GitVersion.MsBuild" Version="$(GitVersionMsBuildVersion)" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/SQuan.Helpers.SQLite.Spatial/SQuan.Helpers.SQLite.Spatial.csproj
+++ b/src/SQuan.Helpers.SQLite.Spatial/SQuan.Helpers.SQLite.Spatial.csproj
@@ -52,7 +52,7 @@
   </Target>
 
   <ItemGroup Label="Package">
-    <PackageReference Include="GitVersion.MsBuild" Version="6.4.0" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="$(GitVersionMsBuildVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#163 

Introduces a new `BPExtrasAttribute` + source generator pair to bridge `CommunityToolkit.Maui.BindablePropertyAttribute` callbacks to instance/partial methods, enabling a `CommunityToolkit`-style `[BindableProperty(PropertyChangedMethodName=...)]` workflow while still writing partial methods.

**Changes:**
- Added `BPExtrasAttribute` and `BPExtrasGenerator` to generate static callback wrappers + partial method declarations.
- Updated sample views/pages and unit-test types to use `CommunityToolkit.Maui.BindablePropertyAttribute` (via alias) and `[BPExtras]` where needed.
- Bumped MAUI/CommunityToolkit package versions and adjusted build warnings configuration.